### PR TITLE
bm:bugfix: Use the right measuring unit for time for subscriber

### DIFF
--- a/bm/src/subscriber.rs
+++ b/bm/src/subscriber.rs
@@ -52,8 +52,8 @@ impl Subscriber {
             //  |---------------------------|---------------------------|
             //  |    t(stored in payload)   |      we need this part    |
             let now = Instant::now();
-            let t_secs = (t / 1000000) as u64;
-            let t_nanos = (t % 1000000 * 1000) as u32;
+            let t_secs = (t / 1000000000) as u64;
+            let t_nanos = (t % 1000000000) as u32;
             let t = Duration::new(t_secs, t_nanos);
             let trip_time = now.duration_since(self.time_reference).saturating_sub(t);
             self.trips_time.push(trip_time);


### PR DESCRIPTION
This bug existed ever since bm was created, but patch 8db563c109b5230b
made it less subtle. The problem was that for some of the publish
functions time was sent in microseconds and for other time was sent in
nano seconds. When refactoring publishers all of them where using
nanosecond at the unit for time measurements, However, the subscribers
were still using milliseconds. This patch addresses this bug by making
ns the measuring unit of time in subscribers.

Signed-off-by: cgv6n3qy <apiformes@protonmail.com>